### PR TITLE
feat: update all_lint_rules.yaml with Flutter 3.10 / Dart 3.0

### DIFF
--- a/packages/altive_lints/example/pubspec.lock
+++ b/packages/altive_lints/example/pubspec.lock
@@ -7,40 +7,52 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.6.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.1"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -50,8 +62,9 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"

--- a/packages/altive_lints/example/pubspec.yaml
+++ b/packages/altive_lints/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A example of altive_lints.
 publish_to: "none"
 version: 1.0.0
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/altive_lints/lib/all_lint_rules.yaml
+++ b/packages/altive_lints/lib/all_lint_rules.yaml
@@ -8,7 +8,6 @@ linter:
     - always_use_package_imports
     - annotate_overrides
     - avoid_annotating_with_dynamic
-    # - avoid_as # Removed in Dart 3.0.0
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
@@ -63,6 +62,7 @@ linter:
     - dangling_library_doc_comments
     - depend_on_referenced_packages
     - deprecated_consistency
+    - deprecated_member_use_from_same_package
     - diagnostic_describe_all_properties
     - directives_ordering
     - discarded_futures
@@ -70,7 +70,6 @@ linter:
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
-    - enable_null_safety
     - eol_at_end_of_file
     - exhaustive_cases
     - file_names
@@ -78,7 +77,8 @@ linter:
     - hash_and_equals
     - implementation_imports
     - implicit_call_tearoffs
-    # - invariant_booleans # Removed in Dart 3.0.0
+    - implicit_reopen
+    - invalid_case_patterns
     - iterable_contains_unrelated_type
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
@@ -89,12 +89,14 @@ linter:
     - lines_longer_than_80_chars
     - list_remove_unrelated_type
     - literal_only_boolean_expressions
+    - matching_super_parameters
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
+    - no_literal_bool_comparisons
     - no_logic_in_create_state
     - no_runtimeType_toString
     - non_constant_identifier_names
@@ -112,7 +114,6 @@ linter:
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
     - prefer_asserts_with_message
-    # - prefer_bool_in_asserts # Removed in Dart 3.0.0
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -166,10 +167,11 @@ linter:
     - tighten_type_of_initializing_formals
     - type_annotate_public_apis
     - type_init_formals
+    - type_literal_in_constant_pattern
     - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
-    # - unnecessary_breaks # Linter Unreleased
+    - unnecessary_breaks
     - unnecessary_const
     - unnecessary_constructor_name
     - unnecessary_final

--- a/packages/altive_lints/pubspec.yaml
+++ b/packages/altive_lints/pubspec.yaml
@@ -4,4 +4,4 @@ version: 1.6.1
 homepage: https://github.com/altive/altive_lints
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
### Flutter 3.10 / Dart 3で追加されたリントルール

- `deprecated_member_use_from_same_package`
同パッケージ内で非推奨メンバーが使用された場合に警告
- `implicit_reopen`
意図しないクラスの拡張等を防ぐために@reopenを使用することを強制させる
- `invalid_case_patterns`
Dart 3では不正となる caseパターンを警告
- `matching_super_parameters`
super パラメータが対応する super constructor のパラメータ名と一致しない場合に警告
- `no_literal_bool_comparisons`
非NULLなbool型に対する等号演算にtrueやfalseを使用すると警告
- `type_literal_in_constant_pattern`
パターンにおいて、 == ではなく型リテラルを使用すると警告
- `unnecessary_breaks`
switch-case において、空ケース以外の不要な break を警告

### 削除されたリントルール
- `enable_null_safety`