### PR TITLE
feat: Add `prefer_sliver_prefix` rule

### DIFF
--- a/packages/altive_lints/lib/altive_lints.dart
+++ b/packages/altive_lints/lib/altive_lints.dart
@@ -4,6 +4,7 @@ import 'src/lints/avoid_hardcoded_color.dart';
 import 'src/lints/avoid_hardcoded_japanese.dart';
 import 'src/lints/avoid_shrink_wrap_in_list_view.dart';
 import 'src/lints/avoid_single_child.dart';
+import 'src/lints/prefer_sliver_prefix.dart';
 
 PluginBase createPlugin() => _AltivePlugin();
 
@@ -14,5 +15,6 @@ class _AltivePlugin extends PluginBase {
         const AvoidHardcodedJapanese(),
         const AvoidShrinkWrapInListView(),
         const AvoidSingleChild(),
+        const PreferSliverPrefix(),
       ];
 }

--- a/packages/altive_lints/lib/src/lints/prefer_sliver_prefix.dart
+++ b/packages/altive_lints/lib/src/lints/prefer_sliver_prefix.dart
@@ -1,0 +1,76 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:collection/collection.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A `prefer_sliver_prefix` rule that ensures widgets returning
+/// a Sliver-type widget have a "Sliver" prefix in their class names.
+///
+/// This naming convention improves code readability and
+/// consistency by clearly indicating the widget's functionality and
+/// return type through its name.
+///
+/// ### Example
+///
+/// #### BAD:
+///
+/// ```dart
+/// class MyCustomList extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     return SliverList(...); // LINT
+///   }
+/// }
+/// ```
+///
+/// #### GOOD:
+///
+/// ```dart
+/// class SliverMyCustomList extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     return SliverList(...);
+///   }
+/// }
+/// ```
+class PreferSliverPrefix extends DartLintRule {
+  const PreferSliverPrefix() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'prefer_sliver_prefix',
+    problemMessage: 'Widgets returning Sliver should have a "Sliver" prefix.',
+    correctionMessage: 'Consider adding "Sliver" prefix to the widget name.',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addClassDeclaration((node) {
+      final className = node.name.lexeme;
+      final methodBody = node.members
+          .whereType<MethodDeclaration>()
+          .firstWhereOrNull((method) => method.name.lexeme == 'build')
+          ?.body;
+
+      if (methodBody is BlockFunctionBody) {
+        final returnStatements =
+            methodBody.block.statements.whereType<ReturnStatement>();
+        final returnsSliverWidget = returnStatements.any(
+          (returnStatement) {
+            final returnType = returnStatement.expression?.staticType;
+            final typeName =
+                returnType?.getDisplayString(withNullability: false);
+            return typeName?.startsWith('Sliver') ?? false;
+          },
+        );
+
+        if (returnsSliverWidget && !className.startsWith('Sliver')) {
+          reporter.reportErrorForNode(_code, node);
+        }
+      }
+    });
+  }
+}

--- a/packages/altive_lints/lint_test/lints/prefer_sliver_prefix.dart
+++ b/packages/altive_lints/lint_test/lints/prefer_sliver_prefix.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+// expect_lint: prefer_sliver_prefix
+class MyWidget extends StatelessWidget {
+  const MyWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverList.builder(
+      itemCount: 10,
+      itemBuilder: (context, index) {
+        return const Placeholder();
+      },
+    );
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issues
<!-- Please list any related Issues or Issues that will be resolved by this PR -->
- None

## 🙌 What's Done
<!-- What has been done in this Pull Request? -->
- Add `prefer_sliver_prefix` rule

## ✍️ What's Not Done
<!-- What is not done in this Pull Request? If none, write "None". -->
- None

## 🖼️ Image Differences
<!-- Attach Before and After capture images or videos if there are UI changes. -->

![CleanShot 2024-07-29 at 18 04 32](https://github.com/user-attachments/assets/47799377-5c32-4779-841b-bf4504bd0756)

## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [ ] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

This rule ensures that class names are consistent and easily recognizable as returning a Sliver widget!

## Pre-launch Checklist
- [x] I have reviewed my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I updated/added relevant documentation (doc comments with ///).