### PR TITLE
build: Bump minimum support analyzer version to 6.5.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
         "writeln"
     ],
     "cSpell.ignorePaths": [
+        "**/.pub-cache",
         "package-lock.json",
         "pubspec.lock",
         "node_modules",

--- a/packages/altive_lints/lib/src/lints/avoid_consecutive_sliver_to_box_adapter.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_consecutive_sliver_to_box_adapter.dart
@@ -66,7 +66,7 @@ class AvoidConsecutiveSliverToBoxAdapter extends DartLintRule {
       while (iterator.moveNext()) {
         final next = iterator.current;
         if (_useSliverToBoxAdapter(current) && _useSliverToBoxAdapter(next)) {
-          reporter.reportErrorForNode(_code, node);
+          reporter.atNode(node, _code);
           return;
         }
         current = next;
@@ -82,8 +82,7 @@ class AvoidConsecutiveSliverToBoxAdapter extends DartLintRule {
   }
 
   bool _isSliverToBoxAdapter(Expression expression) {
-    final typeName =
-        expression.staticType?.getDisplayString(withNullability: false);
+    final typeName = expression.staticType?.getDisplayString();
     return typeName == 'SliverToBoxAdapter';
   }
 
@@ -96,8 +95,7 @@ class AvoidConsecutiveSliverToBoxAdapter extends DartLintRule {
     for (final argument in arguments) {
       if (argument is NamedExpression && argument.name.label.name == 'sliver') {
         final sliverExpression = argument.expression;
-        final sliverTypeName = sliverExpression.staticType
-            ?.getDisplayString(withNullability: false);
+        final sliverTypeName = sliverExpression.staticType?.getDisplayString();
         if (sliverTypeName == 'SliverToBoxAdapter') {
           return true;
         }

--- a/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
@@ -45,11 +45,10 @@ class AvoidHardcodedColor extends DartLintRule {
     CustomLintContext context,
   ) {
     context.registry.addInstanceCreationExpression((node) {
-      final typeName =
-          node.staticType?.getDisplayString(withNullability: false);
+      final typeName = node.staticType?.getDisplayString();
 
       if (typeName == 'Color') {
-        reporter.reportErrorForNode(code, node);
+        reporter.atNode(node, code);
       }
     });
 
@@ -60,7 +59,7 @@ class AvoidHardcodedColor extends DartLintRule {
         if (element is PropertyAccessorElement) {
           final returnType = element.returnType;
           if (_isColorType(returnType)) {
-            reporter.reportErrorForNode(code, node);
+            reporter.atNode(node, code);
           }
         }
       }
@@ -70,9 +69,8 @@ class AvoidHardcodedColor extends DartLintRule {
   bool _isColorType(DartType? type) {
     return type != null &&
         (type.isDartCoreInt ||
-            type.getDisplayString(withNullability: false) == 'Color' ||
-            type.getDisplayString(withNullability: false) == 'MaterialColor' ||
-            type.getDisplayString(withNullability: false) ==
-                'MaterialAccentColor');
+            type.getDisplayString() == 'Color' ||
+            type.getDisplayString() == 'MaterialColor' ||
+            type.getDisplayString() == 'MaterialAccentColor');
   }
 }

--- a/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
@@ -48,7 +48,7 @@ class AvoidHardcodedColor extends DartLintRule {
       final typeName = node.staticType?.getDisplayString();
 
       if (typeName == 'Color') {
-        reporter.atNode(node, code);
+        reporter.atNode(node, _lintCode);
       }
     });
 
@@ -59,7 +59,7 @@ class AvoidHardcodedColor extends DartLintRule {
         if (element is PropertyAccessorElement) {
           final returnType = element.returnType;
           if (_isColorType(returnType)) {
-            reporter.atNode(node, code);
+            reporter.atNode(node, _lintCode);
           }
         }
       }

--- a/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
@@ -28,9 +28,9 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 /// );
 /// ```
 class AvoidHardcodedColor extends DartLintRule {
-  const AvoidHardcodedColor() : super(code: _lintCode);
+  const AvoidHardcodedColor() : super(code: _code);
 
-  static const _lintCode = LintCode(
+  static const _code = LintCode(
     name: 'avoid_hardcoded_color',
     problemMessage: 'Avoid using hardcoded color. Use ColorScheme, '
         'ThemeExtension, or other Theme-based color definitions instead. '
@@ -48,7 +48,7 @@ class AvoidHardcodedColor extends DartLintRule {
       final typeName = node.staticType?.getDisplayString();
 
       if (typeName == 'Color') {
-        reporter.atNode(node, _lintCode);
+        reporter.atNode(node, _code);
       }
     });
 
@@ -59,7 +59,7 @@ class AvoidHardcodedColor extends DartLintRule {
         if (element is PropertyAccessorElement) {
           final returnType = element.returnType;
           if (_isColorType(returnType)) {
-            reporter.atNode(node, _lintCode);
+            reporter.atNode(node, _code);
           }
         }
       }

--- a/packages/altive_lints/lib/src/lints/avoid_hardcoded_japanese.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_hardcoded_japanese.dart
@@ -45,14 +45,14 @@ class AvoidHardcodedJapanese extends DartLintRule {
         return;
       }
       if (isJapanese(stringValue)) {
-        reporter.reportErrorForNode(_code, node);
+        reporter.atNode(node, _code);
       }
     });
 
     context.registry.addStringInterpolation((node) {
       final stringValue = node.toSource();
       if (isJapanese(stringValue)) {
-        reporter.reportErrorForNode(_code, node);
+        reporter.atNode(node, _code);
       }
     });
   }

--- a/packages/altive_lints/lib/src/lints/avoid_shrink_wrap_in_list_view.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_shrink_wrap_in_list_view.dart
@@ -63,7 +63,7 @@ class AvoidShrinkWrapInListView extends DartLintRule {
       if (isListViewWidget(node.staticType) &&
           _hasShrinkWrap(node) &&
           _hasParentList(node)) {
-        reporter.reportErrorForNode(_code, node);
+        reporter.atNode(node, _code);
       }
     });
   }

--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -50,8 +50,7 @@ class AvoidSingleChild extends DartLintRule {
     CustomLintContext context,
   ) {
     context.registry.addInstanceCreationExpression((node) {
-      final className =
-          node.staticType?.getDisplayString(withNullability: false);
+      final className = node.staticType?.getDisplayString();
       if ([
         'Column',
         'Row',
@@ -71,7 +70,7 @@ class AvoidSingleChild extends DartLintRule {
             : null;
 
         if (childrenList != null && childrenList.elements.length == 1) {
-          reporter.reportErrorForNode(_code, node);
+          reporter.atNode(node, _code);
         }
       }
     });

--- a/packages/altive_lints/lib/src/lints/prefer_clock_now.dart
+++ b/packages/altive_lints/lib/src/lints/prefer_clock_now.dart
@@ -43,7 +43,7 @@ class PreferClockNow extends DartLintRule {
         return;
       }
       if (node.constructorName.name?.name == 'now') {
-        reporter.reportErrorForNode(_code, node);
+        reporter.atNode(node, _code);
       }
     });
   }

--- a/packages/altive_lints/lib/src/lints/prefer_dedicated_media_query_methods.dart
+++ b/packages/altive_lints/lib/src/lints/prefer_dedicated_media_query_methods.dart
@@ -49,7 +49,7 @@ class PreferDedicatedMediaQueryMethods extends DartLintRule {
       final method = node.methodName.name;
       final target = node.target?.toString();
       if (target == 'MediaQuery' && (method == 'of' || method == 'maybeOf')) {
-        reporter.reportErrorForNode(_code, node);
+        reporter.atNode(node, _code);
       }
     });
   }

--- a/packages/altive_lints/lib/src/lints/prefer_sliver_prefix.dart
+++ b/packages/altive_lints/lib/src/lints/prefer_sliver_prefix.dart
@@ -61,14 +61,13 @@ class PreferSliverPrefix extends DartLintRule {
         final returnsSliverWidget = returnStatements.any(
           (returnStatement) {
             final returnType = returnStatement.expression?.staticType;
-            final typeName =
-                returnType?.getDisplayString(withNullability: false);
+            final typeName = returnType?.getDisplayString();
             return typeName?.startsWith('Sliver') ?? false;
           },
         );
 
         if (returnsSliverWidget && !className.startsWith('Sliver')) {
-          reporter.reportErrorForNode(_code, node);
+          reporter.atNode(node, _code);
         }
       }
     });

--- a/packages/altive_lints/lib/src/lints/prefer_space_between_elements.dart
+++ b/packages/altive_lints/lib/src/lints/prefer_space_between_elements.dart
@@ -69,7 +69,7 @@ class PreferSpaceBetweenElements extends DartLintRule {
             nextMember is MethodDeclaration &&
             nextMember.name.lexeme == 'build') {
           if (!_hasBlankLineBetween(currentMember, nextMember, lineInfo)) {
-            reporter.atNode(nextMember, code);
+            reporter.atNode(nextMember, _code);
           }
         }
 
@@ -77,7 +77,7 @@ class PreferSpaceBetweenElements extends DartLintRule {
         if (currentMember is FieldDeclaration &&
             nextMember is ConstructorDeclaration) {
           if (!_hasBlankLineBetween(currentMember, nextMember, lineInfo)) {
-            reporter.atNode(nextMember, code);
+            reporter.atNode(nextMember, _code);
           }
         }
 
@@ -85,7 +85,7 @@ class PreferSpaceBetweenElements extends DartLintRule {
         if (currentMember is ConstructorDeclaration &&
             nextMember is FieldDeclaration) {
           if (!_hasBlankLineBetween(currentMember, nextMember, lineInfo)) {
-            reporter.atNode(nextMember, code);
+            reporter.atNode(nextMember, _code);
           }
         }
 
@@ -94,7 +94,7 @@ class PreferSpaceBetweenElements extends DartLintRule {
             nextMember is MethodDeclaration &&
             nextMember.name.lexeme == 'build') {
           if (!_hasBlankLineBetween(currentMember, nextMember, lineInfo)) {
-            reporter.atNode(nextMember, code);
+            reporter.atNode(nextMember, _code);
           }
         }
       }

--- a/packages/altive_lints/lib/src/lints/prefer_space_between_elements.dart
+++ b/packages/altive_lints/lib/src/lints/prefer_space_between_elements.dart
@@ -69,7 +69,7 @@ class PreferSpaceBetweenElements extends DartLintRule {
             nextMember is MethodDeclaration &&
             nextMember.name.lexeme == 'build') {
           if (!_hasBlankLineBetween(currentMember, nextMember, lineInfo)) {
-            reporter.reportErrorForNode(code, nextMember);
+            reporter.atNode(nextMember, code);
           }
         }
 
@@ -77,7 +77,7 @@ class PreferSpaceBetweenElements extends DartLintRule {
         if (currentMember is FieldDeclaration &&
             nextMember is ConstructorDeclaration) {
           if (!_hasBlankLineBetween(currentMember, nextMember, lineInfo)) {
-            reporter.reportErrorForNode(code, nextMember);
+            reporter.atNode(nextMember, code);
           }
         }
 
@@ -85,7 +85,7 @@ class PreferSpaceBetweenElements extends DartLintRule {
         if (currentMember is ConstructorDeclaration &&
             nextMember is FieldDeclaration) {
           if (!_hasBlankLineBetween(currentMember, nextMember, lineInfo)) {
-            reporter.reportErrorForNode(code, nextMember);
+            reporter.atNode(nextMember, code);
           }
         }
 
@@ -94,7 +94,7 @@ class PreferSpaceBetweenElements extends DartLintRule {
             nextMember is MethodDeclaration &&
             nextMember.name.lexeme == 'build') {
           if (!_hasBlankLineBetween(currentMember, nextMember, lineInfo)) {
-            reporter.reportErrorForNode(code, nextMember);
+            reporter.atNode(nextMember, code);
           }
         }
       }

--- a/packages/altive_lints/lib/src/utils/types_utils.dart
+++ b/packages/altive_lints/lib/src/utils/types_utils.dart
@@ -37,26 +37,21 @@ bool isWidgetStateOrSubclass(DartType? type) =>
 bool isSubclassOfListenable(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isListenable);
 
-bool isListViewWidget(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'ListView';
+bool isListViewWidget(DartType? type) => type?.getDisplayString() == 'ListView';
 
 bool isSingleChildScrollViewWidget(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'SingleChildScrollView';
+    type?.getDisplayString() == 'SingleChildScrollView';
 
-bool isColumnWidget(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'Column';
+bool isColumnWidget(DartType? type) => type?.getDisplayString() == 'Column';
 
-bool isRowWidget(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'Row';
+bool isRowWidget(DartType? type) => type?.getDisplayString() == 'Row';
 
-bool isPaddingWidget(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'Padding';
+bool isPaddingWidget(DartType? type) => type?.getDisplayString() == 'Padding';
 
 bool isBuildContext(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'BuildContext';
+    type?.getDisplayString() == 'BuildContext';
 
-bool isGameWidget(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'GameWidget';
+bool isGameWidget(DartType? type) => type?.getDisplayString() == 'GameWidget';
 
 bool _checkSelfOrSupertypes(
   DartType? type,
@@ -65,8 +60,7 @@ bool _checkSelfOrSupertypes(
     predicate(type) ||
     (type is InterfaceType && type.allSupertypes.any(predicate));
 
-bool _isWidget(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'Widget';
+bool _isWidget(DartType? type) => type?.getDisplayString() == 'Widget';
 
 bool _isSubclassOfWidget(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isWidget);
@@ -92,38 +86,34 @@ bool _isFuture(DartType type) =>
     type is InterfaceType &&
     isWidgetOrSubclass(type.typeArguments.firstOrNull);
 
-bool _isListenable(DartType type) =>
-    type.getDisplayString(withNullability: false) == 'Listenable';
+bool _isListenable(DartType type) => type.getDisplayString() == 'Listenable';
 
 bool _isRenderObject(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'RenderObject';
+    type?.getDisplayString() == 'RenderObject';
 
 bool _isSubclassOfRenderObject(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isRenderObject);
 
 bool _isRenderObjectWidget(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'RenderObjectWidget';
+    type?.getDisplayString() == 'RenderObjectWidget';
 
 bool _isSubclassOfRenderObjectWidget(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isRenderObjectWidget);
 
 bool _isRenderObjectElement(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'RenderObjectElement';
+    type?.getDisplayString() == 'RenderObjectElement';
 
 bool _isSubclassOfRenderObjectElement(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isRenderObjectElement);
 
 bool _isMultiProvider(DartType? type) =>
-    type?.getDisplayString(withNullability: false) == 'MultiProvider';
+    type?.getDisplayString() == 'MultiProvider';
 
 bool _isSubclassOfInheritedProvider(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isInheritedProvider);
 
 bool _isInheritedProvider(DartType? type) =>
-    type != null &&
-    type
-        .getDisplayString(withNullability: false)
-        .startsWith('InheritedProvider<');
+    type != null && type.getDisplayString().startsWith('InheritedProvider<');
 
 bool _isIterableInheritedProvider(DartType type) =>
     type.isDartCoreIterable &&

--- a/packages/altive_lints/pubspec.yaml
+++ b/packages/altive_lints/pubspec.yaml
@@ -15,12 +15,6 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  analyzer: ^6.4.1
+  analyzer: ^6.5.0
   collection: ^1.18.0
   custom_lint_builder: ^0.6.4
-
-dependency_overrides:
-  # As of 2024/7/31, the latest Flutter Stable cannot use analyzer ^6.5.0 or 
-  # higher due to the version specification of the dependent meta package. 
-  # Therefore, the analyzer version is fixed at 6.4.1.
-  analyzer: 6.4.1


### PR DESCRIPTION
## 🔗 Related Issues
<!-- Please list any related Issues or Issues that this PR will resolve -->
- closes #39 

## 🙌 What's Done
<!-- What has been done in this Pull Request? -->
- 'reportErrorForNode' is deprecated and shouldn't be used. Use atNode() instead. Try replacing the use of the deprecated member with the replacement.
  - Replaced from `reportErrorForNode(code, node)` to `reporter.atNode(node, code)`
- 'withNullability' is deprecated and shouldn't be used. Only non-nullable by default mode is supported. Try replacing the use of the deprecated member with the replacement.
  - Replaced from `getDisplayString(withNullability: false)` to `getDisplayString()`

## ✍️ What's Not Done
<!-- What is not done in this Pull Request? If none, write "None". -->
None.

## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [ ] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

- reference commits: https://github.com/rrousselGit/riverpod/commit/03a5e893122727084fb35f7c50bc1f65e6384c24

## Pre-launch Checklist
- [x] I have reviewed my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I updated/added relevant documentation (doc comments with ///).