### PR TITLE
fix: Exclude collection-for from the warning of avoid_single_child

### DIFF
--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -72,7 +72,7 @@ class AvoidSingleChild extends DartLintRule {
           return;
         }
 
-        if (childrenList.elements.length > 1) {
+        if (childrenList.elements.length != 1) {
           return;
         }
 

--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -64,15 +64,23 @@ class AvoidSingleChild extends DartLintRule {
           (arg) => arg is NamedExpression && arg.name.label.name == 'children',
         );
 
-        final childrenList = childrenArg is NamedExpression
-            ? childrenArg.expression is ListLiteral
-                ? childrenArg.expression as ListLiteral
-                : null
-            : null;
-
-        if (childrenList != null && childrenList.elements.length == 1) {
-          reporter.atNode(node, _code);
+        final ListLiteral childrenList;
+        if (childrenArg is NamedExpression &&
+            childrenArg.expression is ListLiteral) {
+          childrenList = childrenArg.expression as ListLiteral;
+        } else {
+          return;
         }
+
+        if (childrenList.elements.length > 1) {
+          return;
+        }
+
+        final element = childrenList.elements.first;
+        if (element is ForElement) {
+          return;
+        }
+        reporter.atNode(node, _code);
       }
     });
   }

--- a/packages/altive_lints/lint_test/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lint_test/lints/avoid_single_child.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 
 class MyWidget extends StatelessWidget {
@@ -5,6 +7,7 @@ class MyWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final random = Random();
     return ListView(
       children: [
         // expect_lint: avoid_single_child
@@ -44,11 +47,33 @@ class MyWidget extends StatelessWidget {
             Text('World'),
           ],
         ),
+        // expect_lint: avoid_single_child
+        Column(
+          children: [
+            if (random.nextBool()) const Text('Hello World'),
+          ],
+        ),
         ListView(
           children: List.generate(
             10,
             (index) => Text('Hello $index'),
           ),
+        ),
+        Row(
+          children: [
+            for (var i = 0; i < 10; i++) Text('Hello $i'),
+          ],
+        ),
+        SliverList.list(
+          children: [
+            for (final e in ['a', 'b', 'c']) Text('Hello $e'),
+          ],
+        ),
+        Column(
+          children: [
+            if (random.nextBool()) const Text('Hello 1'),
+            if (random.nextBool()) const Text('Hello 2'),
+          ],
         ),
       ],
     );

--- a/packages/altive_lints/lint_test/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lint_test/lints/avoid_single_child.dart
@@ -75,6 +75,8 @@ class MyWidget extends StatelessWidget {
             if (random.nextBool()) const Text('Hello 2'),
           ],
         ),
+        const Column(),
+        const Column(children: []), // ignore: avoid_redundant_argument_values
       ],
     );
   }

--- a/packages/altive_lints/lint_test/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lint_test/lints/avoid_single_child.dart
@@ -53,6 +53,26 @@ class MyWidget extends StatelessWidget {
             if (random.nextBool()) const Text('Hello World'),
           ],
         ),
+        // expect_lint: avoid_single_child
+        Column(
+          children: [
+            if (random.nextBool())
+              const Text('Hello World')
+            else ...[
+              const Text('Hello'),
+              const Text('World'),
+            ],
+          ],
+        ),
+        if (random.nextBool())
+          const Text('Hello World')
+        else
+          const Column(
+            children: [
+              Text('Hello'),
+              Text('World'),
+            ],
+          ),
         ListView(
           children: List.generate(
             10,

--- a/packages/altive_lints/lint_test/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lint_test/lints/avoid_single_child.dart
@@ -64,6 +64,16 @@ class MyWidget extends StatelessWidget {
             ],
           ],
         ),
+        Column(
+          children: random.nextBool()
+              ? [
+                  const Text('Hello World'),
+                ]
+              : [
+                  const Text('Hello'),
+                  const Text('World'),
+                ],
+        ),
         if (random.nextBool())
           const Text('Hello World')
         else


### PR DESCRIPTION
## 🔗 Related Issues
<!-- Please list any related Issues or Issues that will be resolved by this PR -->
- closes #42
- closes #51

## 🙌 What's Done
<!-- What has been done in this Pull Request? -->
- Exclude collection-for from the warning of avoid_single_child

## ✍️ What's Not Done
<!-- What is not done in this Pull Request? If none, write "None". -->
- Exclude collection-if from the warning of avoid_single_child

## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [ ] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

## Pre-launch Checklist
- [x] I have reviewed my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I updated/added relevant documentation (doc comments with ///).