### PR TITLE
fix: Exclude `AvoidHardcodedJapanese` from warnings for file names ending in `_test.dart`.

### DIFF
--- a/packages/altive_lints/lib/src/lints/avoid_hardcoded_japanese.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_hardcoded_japanese.dart
@@ -40,6 +40,9 @@ class AvoidHardcodedJapanese extends DartLintRule {
     ErrorReporter reporter,
     CustomLintContext context,
   ) {
+    if (resolver.source.shortName.endsWith('_test.dart')) {
+      return;
+    }
     context.registry.addSimpleStringLiteral((node) {
       final stringValue = node.stringValue;
       if (stringValue == null) {

--- a/packages/altive_lints/lint_test/lints/avoid_hardcoded_japanese_test.dart
+++ b/packages/altive_lints/lint_test/lints/avoid_hardcoded_japanese_test.dart
@@ -1,0 +1,10 @@
+// Check the `avoid_hardcoded_japanese` rule.
+//
+// This file ends with the name `_test.dart`,
+// so it should be exempt from the warning.
+
+const hiragana = 'あいうえお';
+
+const katakana = 'アイウエオ';
+
+const kanji = '漢字';


### PR DESCRIPTION
## 🔗 Related Issues
<!-- Please list any related Issues or Issues that will be resolved by this PR -->
- closes #47

## 🙌 What's Done
<!-- What has been done in this Pull Request? -->
- Exclude `AvoidHardcodedJapanese` from warnings for file names ending in `_test.dart`.

## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [ ] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

## Pre-launch Checklist
- [x] I have reviewed my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I updated/added relevant documentation (doc comments with ///).