### PR TITLE
fix: Exclude Colors.transparent from the target of avoid_hardcoded_color

### DIFF
--- a/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
@@ -59,6 +59,10 @@ class AvoidHardcodedColor extends DartLintRule {
         final element = node.staticElement;
         if (element is PropertyAccessorElement) {
           final returnType = element.returnType;
+          // Allow Colors.transparent as a valid hardcoded color, as it serves.
+          if (node.identifier.name == 'transparent') {
+            return; 
+          }
           if (_isColorType(returnType)) {
             reporter.atNode(node, _code);
           }

--- a/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
@@ -61,7 +61,7 @@ class AvoidHardcodedColor extends DartLintRule {
           final returnType = element.returnType;
           // Allow Colors.transparent as a valid hardcoded color, as it serves.
           if (node.identifier.name == 'transparent') {
-            return; 
+            return;
           }
           if (_isColorType(returnType)) {
             reporter.atNode(node, _code);

--- a/packages/altive_lints/lint_test/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/lint_test/lints/avoid_hardcoded_color.dart
@@ -14,6 +14,8 @@ class MyWidget extends StatelessWidget {
         // expect_lint: avoid_hardcoded_color
         const ColoredBox(color: Colors.green),
         ColoredBox(color: Theme.of(context).colorScheme.primary),
+
+        const ColoredBox(color: Colors.transparent),
       ],
     );
   }


### PR DESCRIPTION
## 🔗 Related Issues
<!-- Please list any related Issues or Issues that will be resolved by this PR -->
- closes #59 

## 🙌 What's Done
<!-- What has been done in this Pull Request? -->
- Exclude Colors.transparent from the target of avoid_hardcoded_color

## ✍️ What's Not Done
<!-- What is not done in this Pull Request? If none, write "None". -->
- 


## 🖼️ Image Differences
<!-- Attach Before and After capture images or videos if there are UI changes. -->

![スクリーンショット 2024-10-07 12 06 07](https://github.com/user-attachments/assets/5551717f-f117-4c2f-a6f1-aaeff566166d)

## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [x] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

## Pre-launch Checklist
- [x] I have reviewed my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I updated/added relevant documentation (doc comments with ///).