### PR TITLE
fix: Resolved warnings false detection in ColorScheme definition

### DIFF
--- a/packages/altive_lints/example/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/example/lints/avoid_hardcoded_color.dart
@@ -20,22 +20,6 @@ class MyWidget extends StatelessWidget {
     );
   }
 }
-ColorScheme get _colorScheme => const ColorScheme(
+ColorScheme get _colorScheme => const ColorScheme.dark(
       primary:Color.fromRGBO(0, 255, 0, 1),
-      secondary: Color(0xFFF45479),
-      onSecondary: Color(0xFFFFFFFF),
-      error: Color(0xFFFF3131),
-      surface: Color(0xFFFEFEFE),
-      surfaceDim: Color(0x1F787880),
-      surfaceTint: Color(0xFFF5F5F5),
-      surfaceContainerLowest: Color(0xFFF7F7F7),
-      surfaceContainerLow: Color(0xFFFAFBFC),
-      surfaceContainerHighest: Color(0xFFFFFFFF),
-      onSurface: Color(0xFF181A1F),
-      onSurfaceVariant: Color(0xFF989898),
-      outline: Color(0xFFDCDCDC),
-      scrim: Colors.black54,
-      onPrimary: Color.fromRGBO(100, 100, 100, 11),
-      onError: Color(0xFFFF3131),
-      brightness: Brightness.dark,
     );

--- a/packages/altive_lints/example/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/example/lints/avoid_hardcoded_color.dart
@@ -14,9 +14,28 @@ class MyWidget extends StatelessWidget {
         // expect_lint: avoid_hardcoded_color
         const ColoredBox(color: Colors.green),
         ColoredBox(color: Theme.of(context).colorScheme.primary),
-
+        ColoredBox(color: _colorScheme.primary),
         const ColoredBox(color: Colors.transparent),
       ],
     );
   }
 }
+ColorScheme get _colorScheme => const ColorScheme(
+      primary:Color.fromRGBO(0, 255, 0, 1),
+      secondary: Color(0xFFF45479),
+      onSecondary: Color(0xFFFFFFFF),
+      error: Color(0xFFFF3131),
+      surface: Color(0xFFFEFEFE),
+      surfaceDim: Color(0x1F787880),
+      surfaceTint: Color(0xFFF5F5F5),
+      surfaceContainerLowest: Color(0xFFF7F7F7),
+      surfaceContainerLow: Color(0xFFFAFBFC),
+      surfaceContainerHighest: Color(0xFFFFFFFF),
+      onSurface: Color(0xFF181A1F),
+      onSurfaceVariant: Color(0xFF989898),
+      outline: Color(0xFFDCDCDC),
+      scrim: Colors.black54,
+      onPrimary: Color.fromRGBO(100, 100, 100, 11),
+      onError: Color(0xFFFF3131),
+      brightness: Brightness.dark,
+    );

--- a/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
@@ -51,7 +51,7 @@ class AvoidHardcodedColor extends DartLintRule {
         return;
       }
       final typeName = node.staticType?.getDisplayString();
-      
+
       if (typeName == 'Color') {
         reporter.atNode(node, _code);
       }

--- a/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
@@ -47,8 +47,11 @@ class AvoidHardcodedColor extends DartLintRule {
     CustomLintContext context,
   ) {
     context.registry.addInstanceCreationExpression((node) {
+     if (_isInsideColorScheme(node)) {
+          return;
+      }
       final typeName = node.staticType?.getDisplayString();
-
+      
       if (typeName == 'Color' && !_isInsideColorScheme(node)) {
         reporter.atNode(node, _code);
       }

--- a/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
@@ -47,12 +47,12 @@ class AvoidHardcodedColor extends DartLintRule {
     CustomLintContext context,
   ) {
     context.registry.addInstanceCreationExpression((node) {
-     if (_isInsideColorScheme(node)) {
-          return;
+      if (_isInsideColorScheme(node)) {
+        return;
       }
       final typeName = node.staticType?.getDisplayString();
       
-      if (typeName == 'Color' && !_isInsideColorScheme(node)) {
+      if (typeName == 'Color') {
         reporter.atNode(node, _code);
       }
     });
@@ -67,7 +67,7 @@ class AvoidHardcodedColor extends DartLintRule {
           if (node.identifier.name == 'transparent') {
             return;
           }
-          if (_isColorType(returnType) && !_isInsideColorScheme(node)) {
+          if (_isColorType(returnType)) {
             reporter.atNode(node, _code);
           }
         }

--- a/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_hardcoded_color.dart
@@ -60,7 +60,7 @@ class AvoidHardcodedColor extends DartLintRule {
         final element = node.staticElement;
         if (element is PropertyAccessorElement) {
           final returnType = element.returnType;
-          // Allow Colors.transparent as a valid hardcoded color.
+          // Allow Colors.transparent as a valid hardcoded color, as it serves.
           if (node.identifier.name == 'transparent') {
             return;
           }


### PR DESCRIPTION
## 🔗 Related Issues
<!-- Please list any related Issues or Issues that will be resolved by this PR -->
- closes #67 

## 🙌 What's Done
<!-- What has been done in this Pull Request? -->
- Resolving the bug that warnings are also displayed in colorScheme definitions.

## ✍️ What's Not Done
<!-- What is not done in this Pull Request? If none, write "None". -->
- 

## 🖼️ Image Differences
<!-- Attach Before and After capture images or videos if there are UI changes. -->

| Before    | After     |
| --------- | --------- |
| __image__ | __image__ |

## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [ ] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

## Pre-launch Checklist
- [ ] I have reviewed my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I updated/added relevant documentation (doc comments with ///).