### PR TITLE
fix: No warning if the number of elements in the spread operator using the if statement is more than two.

### DIFF
--- a/packages/altive_lints/example/lints/avoid_single_child.dart
+++ b/packages/altive_lints/example/lints/avoid_single_child.dart
@@ -7,7 +7,7 @@ class MyWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var isValued = Random().nextBool();
+    final isValued = Random().nextBool();
     final random = Random();
     return ListView(
       children: [

--- a/packages/altive_lints/example/lints/avoid_single_child.dart
+++ b/packages/altive_lints/example/lints/avoid_single_child.dart
@@ -112,7 +112,7 @@ class MyWidget extends StatelessWidget {
             ]
           ],
         ),
-        
+
         Column(
           children: [
             if(isValued)...[
@@ -128,6 +128,7 @@ class MyWidget extends StatelessWidget {
                 ]
               : [
                   const Text('Hello'),
+                  const Text('World'),
                 ],
         ),
         if (random.nextBool())

--- a/packages/altive_lints/example/lints/avoid_single_child.dart
+++ b/packages/altive_lints/example/lints/avoid_single_child.dart
@@ -7,6 +7,7 @@ class MyWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    var isValued = Random().nextBool();
     final random = Random();
     return ListView(
       children: [
@@ -66,7 +67,6 @@ class MyWidget extends StatelessWidget {
               const Text('Hello World')
             else ...[
               const Text('Hello'),
-              const Text('World'),
             ],
           ],
         ),
@@ -115,6 +115,17 @@ class MyWidget extends StatelessWidget {
         // Ignore this for the sake of example.
         // ignore: avoid_redundant_argument_values
         const Column(children: []),
+        // expect_lint: avoid_single_child
+        Column(
+          children: [
+            if(isValued)...[
+              Container(),
+            ]else...[
+              Container(),
+            ],
+          ],
+        ),
+
       ],
     );
   }

--- a/packages/altive_lints/example/lints/avoid_single_child.dart
+++ b/packages/altive_lints/example/lints/avoid_single_child.dart
@@ -80,6 +80,14 @@ class MyWidget extends StatelessWidget {
             ],
           ],
         ),
+        Column(
+          children: [
+            if(isValued)...[
+              Container(),
+            ],
+            Container(),
+          ],
+        ),
         // expect_lint: avoid_single_child
         Column(
           children: [
@@ -110,15 +118,6 @@ class MyWidget extends StatelessWidget {
             else...[
               Container(),
             ]
-          ],
-        ),
-
-        Column(
-          children: [
-            if(isValued)...[
-              Container(),
-            ],
-            Container(),
           ],
         ),
         Column(

--- a/packages/altive_lints/example/lints/avoid_single_child.dart
+++ b/packages/altive_lints/example/lints/avoid_single_child.dart
@@ -96,6 +96,22 @@ class MyWidget extends StatelessWidget {
             ],
           ],
         ),
+        // expect_lint: avoid_single_child
+        Column(
+          children: [
+            if(isValued)...[]
+            else...[]
+          ],
+        ),
+        // expect_lint: avoid_single_child
+        Column(
+          children: [
+            if(isValued)...[]
+            else...[
+              Container(),
+            ]
+          ],
+        ),
         Column(
           children: [
             if(isValued)...[

--- a/packages/altive_lints/example/lints/avoid_single_child.dart
+++ b/packages/altive_lints/example/lints/avoid_single_child.dart
@@ -125,7 +125,6 @@ class MyWidget extends StatelessWidget {
             ],
           ],
         ),
-
       ],
     );
   }

--- a/packages/altive_lints/example/lints/avoid_single_child.dart
+++ b/packages/altive_lints/example/lints/avoid_single_child.dart
@@ -112,6 +112,7 @@ class MyWidget extends StatelessWidget {
             ]
           ],
         ),
+        
         Column(
           children: [
             if(isValued)...[

--- a/packages/altive_lints/example/lints/avoid_single_child.dart
+++ b/packages/altive_lints/example/lints/avoid_single_child.dart
@@ -60,14 +60,48 @@ class MyWidget extends StatelessWidget {
             if (random.nextBool()) const Text('Hello World'),
           ],
         ),
-        // expect_lint: avoid_single_child
         Column(
           children: [
             if (random.nextBool())
               const Text('Hello World')
             else ...[
               const Text('Hello'),
+              const Text('World'),
             ],
+          ],
+        ),
+        // expect_lint: avoid_single_child
+        Column(
+          children: [
+            if(isValued)...[
+              Container(),
+            ]else...[
+              Container(),
+            ],
+          ],
+        ),
+        // expect_lint: avoid_single_child
+        Column(
+          children: [
+            if(isValued)...[
+              Container(),
+            ],
+          ],
+        ),
+        Column(
+          children: [
+            if(isValued)...[
+              Container(),
+              Container(),
+            ],
+          ],
+        ),
+        Column(
+          children: [
+            if(isValued)...[
+              Container(),
+            ],
+            Container(),
           ],
         ),
         Column(
@@ -77,7 +111,6 @@ class MyWidget extends StatelessWidget {
                 ]
               : [
                   const Text('Hello'),
-                  const Text('World'),
                 ],
         ),
         if (random.nextBool())
@@ -115,16 +148,6 @@ class MyWidget extends StatelessWidget {
         // Ignore this for the sake of example.
         // ignore: avoid_redundant_argument_values
         const Column(children: []),
-        // expect_lint: avoid_single_child
-        Column(
-          children: [
-            if(isValued)...[
-              Container(),
-            ]else...[
-              Container(),
-            ],
-          ],
-        ),
       ],
     );
   }

--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -76,7 +76,19 @@ class AvoidSingleChild extends DartLintRule {
         if (childrenList.elements.length != 1) {
           return;
         }
+        for (final element in childrenList.elements) {
+          if (element is IfElement) {
 
+            if (_hasSingleChild(element.thenElement)) {
+              return;
+            }
+
+            if (element.elseElement != null &&
+                _hasSingleChild(element.elseElement!)) {
+              return;
+            }
+          }
+        }
         final element = childrenList.elements.first;
         if (element is ForElement) {
           return;
@@ -84,5 +96,16 @@ class AvoidSingleChild extends DartLintRule {
         reporter.atNode(node, _code);
       }
     });
+  }
+  bool _hasSingleChild(CollectionElement element) {
+    if (element is ListLiteral) {
+      return element.elements.length == 1;
+    } else if (element is SpreadElement) {
+      if (element.expression is ListLiteral) {
+        final listLiteral = element.expression as ListLiteral;
+        return listLiteral.elements.length != 1;
+      }
+    }
+    return false;
   }
 }

--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -76,19 +76,6 @@ class AvoidSingleChild extends DartLintRule {
         if (childrenList.elements.length != 1) {
           return;
         }
-        for (final element in childrenList.elements) {
-          if (element is IfElement) {
-
-            if (_hasSingleChild(element.thenElement)) {
-              return;
-            }
-
-            if (element.elseElement != null &&
-                _hasSingleChild(element.elseElement!)) {
-              return;
-            }
-          }
-        }
         final element = childrenList.elements.first;
         if (element is ForElement) {
           return;
@@ -97,15 +84,5 @@ class AvoidSingleChild extends DartLintRule {
       }
     });
   }
-  bool _hasSingleChild(CollectionElement element) {
-    if (element is ListLiteral) {
-      return element.elements.length == 1;
-    } else if (element is SpreadElement) {
-      if (element.expression is ListLiteral) {
-        final listLiteral = element.expression as ListLiteral;
-        return listLiteral.elements.length != 1;
-      }
-    }
-    return false;
-  }
+
 }

--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -100,7 +100,7 @@ class AvoidSingleChild extends DartLintRule {
   bool _hasMultipleChild(CollectionElement element) {
     if (element is SpreadElement && element.expression is ListLiteral) {
       final spreadElement = element.expression as ListLiteral;
-      return spreadElement.elements.length != 1;
+      return spreadElement.elements.length > 1;
     }
     return false;
   }

--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -98,12 +98,10 @@ class AvoidSingleChild extends DartLintRule {
   }
 
   bool _hasSingleChild(CollectionElement element) {
-    if (element is ListLiteral) {
-      return element.elements.length == 1;
-    } else if (element is SpreadElement) {
+    if (element is SpreadElement) {
       if (element.expression is ListLiteral) {
-        final listLiteral = element.expression as ListLiteral;
-        return listLiteral.elements.length != 1;
+        final spreadElement = element.expression as ListLiteral;
+        return spreadElement.elements.length != 1;
       }
     }
     return false;

--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -98,11 +98,9 @@ class AvoidSingleChild extends DartLintRule {
   }
 
   bool _hasSingleChild(CollectionElement element) {
-    if (element is SpreadElement) {
-      if (element.expression is ListLiteral) {
-        final spreadElement = element.expression as ListLiteral;
-        return spreadElement.elements.length != 1;
-      }
+    if (element is SpreadElement && element.expression is ListLiteral) {
+      final spreadElement = element.expression as ListLiteral;
+      return spreadElement.elements.length != 1;
     }
     return false;
   }

--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -78,7 +78,6 @@ class AvoidSingleChild extends DartLintRule {
         }
         for (final element in childrenList.elements) {
           if (element is IfElement) {
-
             if (_hasSingleChild(element.thenElement)) {
               return;
             }
@@ -97,6 +96,7 @@ class AvoidSingleChild extends DartLintRule {
       }
     });
   }
+
   bool _hasSingleChild(CollectionElement element) {
     if (element is ListLiteral) {
       return element.elements.length == 1;

--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -82,8 +82,8 @@ class AvoidSingleChild extends DartLintRule {
               return;
             }
 
-            if (element.elseElement != null &&
-                _hasMultipleChild(element.elseElement!)) {
+            if (element.elseElement case final CollectionElement ce
+                when _hasMultipleChild(ce)) {
               return;
             }
           }

--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -78,12 +78,12 @@ class AvoidSingleChild extends DartLintRule {
         }
         for (final element in childrenList.elements) {
           if (element is IfElement) {
-            if (_hasSingleChild(element.thenElement)) {
+            if (_hasMultipleChild(element.thenElement)) {
               return;
             }
 
             if (element.elseElement != null &&
-                _hasSingleChild(element.elseElement!)) {
+                _hasMultipleChild(element.elseElement!)) {
               return;
             }
           }
@@ -97,7 +97,7 @@ class AvoidSingleChild extends DartLintRule {
     });
   }
 
-  bool _hasSingleChild(CollectionElement element) {
+  bool _hasMultipleChild(CollectionElement element) {
     if (element is SpreadElement && element.expression is ListLiteral) {
       final spreadElement = element.expression as ListLiteral;
       return spreadElement.elements.length != 1;

--- a/packages/altive_lints/lib/src/lints/avoid_single_child.dart
+++ b/packages/altive_lints/lib/src/lints/avoid_single_child.dart
@@ -76,6 +76,19 @@ class AvoidSingleChild extends DartLintRule {
         if (childrenList.elements.length != 1) {
           return;
         }
+        for (final element in childrenList.elements) {
+          if (element is IfElement) {
+
+            if (_hasSingleChild(element.thenElement)) {
+              return;
+            }
+
+            if (element.elseElement != null &&
+                _hasSingleChild(element.elseElement!)) {
+              return;
+            }
+          }
+        }
         final element = childrenList.elements.first;
         if (element is ForElement) {
           return;
@@ -84,5 +97,15 @@ class AvoidSingleChild extends DartLintRule {
       }
     });
   }
-
+  bool _hasSingleChild(CollectionElement element) {
+    if (element is ListLiteral) {
+      return element.elements.length == 1;
+    } else if (element is SpreadElement) {
+      if (element.expression is ListLiteral) {
+        final listLiteral = element.expression as ListLiteral;
+        return listLiteral.elements.length != 1;
+      }
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
## 🔗 Related Issues
<!-- Please list any related Issues or Issues that will be resolved by this PR -->
- closes #68 

## 🙌 What's Done
<!-- What has been done in this Pull Request? -->
- Do not display a warning if the if statement written to a child element has two or more elements with the spread operator

## ✍️ What's Not Done
<!-- What is not done in this Pull Request? If none, write "None". -->
- 

## 🖼️ Image Differences
<!-- Attach Before and After capture images or videos if there are UI changes. -->

| not display warnings  | warning     |
| --------- | --------- |
| ![スクリーンショット 2024-11-05 16 56 34](https://github.com/user-attachments/assets/5635a2d6-efaa-4bf6-8c27-c8b0b48b0f95) | ![スクリーンショット 2024-11-05 16 56 47](https://github.com/user-attachments/assets/4511c251-d5eb-4d2c-bd34-d3bb6f1fc89f) |

Both if and else will similarly display a warning message if the number of elements is one.

## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [x] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

## Pre-launch Checklist
- [x] I have reviewed my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I updated/added relevant documentation (doc comments with ///).