### PR TITLE
feat: Add assists for macro documentation comments

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "bools",
         "combinators",
         "diffscrape",
+        "endtemplate",
         "gocolly",
         "interps",
         "ints",

--- a/packages/altive_lints/README.md
+++ b/packages/altive_lints/README.md
@@ -21,6 +21,10 @@ There are also Altive-made rules by custom_lint.
   - [prefer\_dedicated\_media\_query\_methods](#prefer_dedicated_media_query_methods)
   - [prefer\_to\_include\_sliver\_in\_name](#prefer_to_include_sliver_in_name)
   - [prefer\_space\_between\_elements](#prefer_space_between_elements)
+- [All assists in altive\_lints](#all-assists-in-altive_lints)
+  - [Add macro template documentation comment](#add-macro-template-documentation-comment)
+  - [Add macro documentation comment](#add-macro-documentation-comment)
+  - [Wrap with macro template documentation comment](#wrap-with-macro-template-documentation-comment)
 - [Lint rules adopted by altive\_lints and why](#lint-rules-adopted-by-altive_lints-and-why)
   - [public\_member\_api\_docs](#public_member_api_docs)
 - [Migration guide](#migration-guide)
@@ -315,6 +319,81 @@ class MyWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(title);
   }
+}
+```
+
+## All assists in altive_lints
+
+### Add macro template documentation comment
+
+Adds a Macros template to class declarations.  
+When you place the cursor on the class declaration and execute **"Add macro template documentation comment"**, the documentation is created.
+
+**Before:**
+
+```dart
+class MyClass {
+  // Class implementation
+}
+```
+
+**After applying the assist:**
+
+```dart
+/// {@template my_package.MyClass}
+///
+/// {@endtemplate}
+class MyClass {
+  // Class implementation
+}
+```
+
+### Add macro documentation comment
+
+Adds Macros comments to constructors and method declarations.  
+When you place the cursor on a constructor or method declaration and execute **"Add macro documentation comment"**, the documentation is created.
+
+**Before:**
+
+```dart
+void myFunction() {
+  // Function implementation
+}
+```
+
+**After applying the assist:**
+
+```dart
+/// {@macro my_package.myFunction}
+void myFunction() {
+  // Function implementation
+}
+```
+
+### Wrap with macro template documentation comment
+
+Wraps existing documentation comments with a Macros template.  
+When you select the documentation comment and execute **"Wrap with macro template documentation comment"**, the documentation is created.
+
+**Before:**
+
+```dart
+/// Some comment
+/// More comments
+class MyClass {
+  // Class implementation
+}
+```
+
+**After applying the assist:**
+
+```dart
+/// {@template my_package.MyClass}
+/// Some comment
+/// More comments
+/// {@endtemplate}
+class MyClass {
+  // Class implementation
 }
 ```
 

--- a/packages/altive_lints/lib/altive_lints.dart
+++ b/packages/altive_lints/lib/altive_lints.dart
@@ -1,5 +1,8 @@
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
+import 'src/assists/add_macro_document_comments.dart';
+import 'src/assists/add_macro_template_document_comment.dart';
+import 'src/assists/wrap_with_macro_template_document_comment.dart';
 import 'src/lints/avoid_consecutive_sliver_to_box_adapter.dart';
 import 'src/lints/avoid_hardcoded_color.dart';
 import 'src/lints/avoid_hardcoded_japanese.dart';
@@ -25,5 +28,12 @@ class _AltivePlugin extends PluginBase {
         const PreferDedicatedMediaQueryMethods(),
         const PreferSpaceBetweenElements(),
         const PreferToIncludeSliverInName(),
+      ];
+
+  @override
+  List<Assist> getAssists() => [
+        AddMacroDocumentComment(),
+        AddMacroTemplateDocumentComment(),
+        WrapWithMacroTemplateDocumentComment(),
       ];
 }

--- a/packages/altive_lints/lib/src/assists/add_macro_document_comments.dart
+++ b/packages/altive_lints/lib/src/assists/add_macro_document_comments.dart
@@ -1,0 +1,88 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/source/source_range.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// {@template altive_lints.AddMacroDocumentComment}
+/// An assist to add macro template documentation comments to function
+/// or constructor declarations.
+///
+/// This assist helps maintain consistent documentation across
+/// the entire codebase by adding macro template comments
+/// to each function or constructor. These comments can be used
+/// for documentation generation or by other tools.
+///
+/// Macro template comments follow this format:
+///
+/// ```dart
+/// /// {[@]macro packageName.functionName}
+/// ```
+///
+/// Example:
+///
+/// Before:
+/// ```dart
+/// void myFunction() {
+///   // Function implementation
+/// }
+/// ```
+///
+/// After applying the assist:
+/// ```dart
+/// /// {[@]macro my_package.myFunction}
+/// void myFunction() {
+///   // Function implementation
+/// }
+/// ```
+///
+/// {@endtemplate}
+class AddMacroDocumentComment extends DartAssist {
+  /// {@macro altive_lints.AddMacroDocumentComment}
+  AddMacroDocumentComment();
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    SourceRange target,
+  ) {
+    context.registry.addFunctionDeclaration((node) {
+      _processNode(node, target, reporter, context);
+    });
+
+    context.registry.addConstructorDeclaration((node) {
+      _processNode(node, target, reporter, context);
+    });
+  }
+
+  void _processNode(
+    AstNode node,
+    SourceRange target,
+    ChangeReporter reporter,
+    CustomLintContext context,
+  ) {
+    if (!target.intersects(node.sourceRange)) {
+      return;
+    }
+
+    final changeBuilder = reporter.createChangeBuilder(
+      message: 'Add macro documentation comment',
+      priority: 20,
+    );
+
+    final packageName = context.pubspec.name;
+    var name = '';
+
+    if (node is FunctionDeclaration) {
+      name = node.name.lexeme;
+    } else if (node is ConstructorDeclaration) {
+      name = node.returnType.name;
+    }
+
+    final macroComment = '/// {@macro $packageName.$name}';
+
+    changeBuilder.addDartFileEdit((builder) {
+      builder.addSimpleInsertion(node.offset, '$macroComment\n');
+    });
+  }
+}

--- a/packages/altive_lints/lib/src/assists/add_macro_template_document_comment.dart
+++ b/packages/altive_lints/lib/src/assists/add_macro_template_document_comment.dart
@@ -1,0 +1,80 @@
+import 'package:analyzer/source/source_range.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// {@template altive_lints.AddMacroTemplateDocumentComment}
+/// A Dart assist that adds a macro template documentation comment to a class
+/// declaration if it does not already have one.
+///
+/// This assist helps in maintaining consistent documentation across the
+/// codebase by ensuring that each class has a macro template comment, which
+/// can be used for generating documentation or for other tooling purposes.
+///
+/// The macro template comment follows the format:
+///
+/// ```dart
+/// /// {[@]template packageName.className}
+/// ///
+/// /// {[@]endtemplate}
+/// ```
+///
+/// Example usage:
+///
+/// Before:
+/// ```dart
+/// class MyClass {
+///   // Class implementation
+/// }
+/// ```
+///
+/// After running the assist:
+/// ```dart
+/// /// {[@]template my_package.MyClass}
+/// ///
+/// /// {[@]endtemplate}
+/// class MyClass {
+///   // Class implementation
+/// }
+/// ```
+///
+/// {@endtemplate}
+class AddMacroTemplateDocumentComment extends DartAssist {
+  /// {@macro altive_lints.AddMacroTemplateDocumentComment}
+  AddMacroTemplateDocumentComment();
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    SourceRange target,
+  ) {
+    context.registry.addClassDeclaration((node) {
+      if (!target.intersects(node.sourceRange)) {
+        return;
+      }
+
+      final docComment = node.documentationComment;
+      if (docComment != null) {
+        return;
+      }
+
+      final changeBuilder = reporter.createChangeBuilder(
+        message: 'Add macro template documentation comment',
+        priority: 20,
+      );
+
+      final packageName = context.pubspec.name;
+      final className = node.name.lexeme;
+
+      final template = [
+        '/// {@template $packageName.$className}',
+        '/// ',
+        '/// {@endtemplate}',
+      ].join('\n');
+
+      changeBuilder.addDartFileEdit((builder) {
+        builder.addSimpleInsertion(node.offset, '$template\n');
+      });
+    });
+  }
+}

--- a/packages/altive_lints/lib/src/assists/wrap_with_macro_template_document_comment.dart
+++ b/packages/altive_lints/lib/src/assists/wrap_with_macro_template_document_comment.dart
@@ -56,6 +56,12 @@ class WrapWithMacroTemplateDocumentComment extends DartAssist {
         return;
       }
 
+      final currentComment = node.tokens.join();
+      if (currentComment.contains('{@template') &&
+          currentComment.contains('{@endtemplate}')) {
+        return;
+      }
+
       if (!node.isDocumentation) {
         return;
       }

--- a/packages/altive_lints/lib/src/assists/wrap_with_macro_template_document_comment.dart
+++ b/packages/altive_lints/lib/src/assists/wrap_with_macro_template_document_comment.dart
@@ -1,0 +1,85 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/source/source_range.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// {@template altive_lints.WrapWithMacroTemplateDocumentComment}
+/// A Dart assist that wraps an existing documentation comment with a macro
+/// template comment.
+///
+/// This assist helps in maintaining consistent documentation across the
+/// codebase by ensuring that each documentation comment is wrapped with a
+/// macro template, which can be used for generating documentation or for
+/// other tooling purposes.
+///
+/// The macro template comment follows the format:
+///
+/// ```dart
+/// /// {[@]template packageName.className}
+/// /// Existing documentation comment.
+/// /// {[@]endtemplate}
+/// ```
+///
+/// Example usage:
+///
+/// Before:
+/// ```dart
+/// /// This is a class.
+/// class MyClass {
+///   // Class implementation
+/// }
+/// ```
+///
+/// After running the assist:
+/// ```dart
+/// /// {[@]template my_package.MyClass}
+/// /// This is a class.
+/// /// {[@]endtemplate}
+/// class MyClass {
+///   // Class implementation
+/// }
+/// ```
+///
+/// {@endtemplate}
+class WrapWithMacroTemplateDocumentComment extends DartAssist {
+  /// {@macro altive_lints.WrapWithMacroTemplateDocumentComment}
+  WrapWithMacroTemplateDocumentComment();
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    SourceRange target,
+  ) {
+    context.registry.addComment((node) {
+      if (!target.intersects(node.sourceRange)) {
+        return;
+      }
+
+      if (!node.isDocumentation) {
+        return;
+      }
+
+      final changeBuilder = reporter.createChangeBuilder(
+        message: 'Wrap with macro template documentation comment',
+        priority: 20,
+      );
+
+      final packageName = context.pubspec.name;
+      final classNode = node.parent;
+      var className = '';
+      if (classNode is ClassDeclaration) {
+        className = classNode.name.lexeme;
+      }
+
+      final templateStart = '/// {@template $packageName.$className}';
+      const templateEnd = '/// {@endtemplate}';
+
+      changeBuilder.addDartFileEdit((builder) {
+        builder
+          ..addSimpleInsertion(node.offset, '$templateStart\n')
+          ..addSimpleInsertion(node.end, '\n$templateEnd');
+      });
+    });
+  }
+}

--- a/packages/altive_lints/lib/src/assists/wrap_with_macro_template_document_comment.dart
+++ b/packages/altive_lints/lib/src/assists/wrap_with_macro_template_document_comment.dart
@@ -62,10 +62,6 @@ class WrapWithMacroTemplateDocumentComment extends DartAssist {
         return;
       }
 
-      if (!node.isDocumentation) {
-        return;
-      }
-
       final changeBuilder = reporter.createChangeBuilder(
         message: 'Wrap with macro template documentation comment',
         priority: 20,


### PR DESCRIPTION
## 🔗 Related Issues
<!-- Please list any related Issues or Issues that will be resolved by this PR -->
- None

## 🙌 What's Done
<!-- What has been done in this Pull Request? -->
- Add assists for macro documentation comments

### Background

https://altive.slack.com/archives/C072SHBR4DT/p1733300766521879
> Since `public_member_api_docs` is `true`, you need to include doc comments for constructors as well. Until now, I’ve been writing comments like `/// Creates an instance of [Xxx].`. However, I felt such comments don’t provide much value when checking them in the reference. 
> 
> Therefore, I thought it might be a good idea to insert the same doc comment as the class using macros, unless there’s something specific to add to the constructor's comment.

To make this adjustment easier, I’ve created an assist feature with `custom_lint`!

## ✍️ What's Not Done
<!-- What is not done in this Pull Request? If none, write "None". -->
- None

## 🖼️ Image Differences
<!-- Attach Before and After capture images or videos if there are UI changes. -->

| Add macro template documentation comment | Add macro documentation comment | Wrap with macro template documentation comment |
|--------|--------|--------|
| ![スクリーンショット 2024-12-09 10 01 51](https://github.com/user-attachments/assets/986fb90e-b388-4534-975f-12c03598fc05) | ![スクリーンショット 2024-12-09 10 02 31](https://github.com/user-attachments/assets/b89d62df-2d95-4cfa-b4c3-28746dd05935) |  ![スクリーンショット 2024-12-09 10 02 11](https://github.com/user-attachments/assets/973e5b77-f3cd-4747-ba06-74a2ad8a1d3c) |
## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [ ] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

## Pre-launch Checklist
- [x] I have reviewed my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I updated/added relevant documentation (doc comments with ///).