### PR TITLE
feat: Disable `specify_nonobvious_local_variable_types` to avoid conflicts

### DIFF
--- a/packages/altive_lints/lib/altive_lints.yaml
+++ b/packages/altive_lints/lib/altive_lints.yaml
@@ -58,6 +58,9 @@ linter:
     # Too verbose. Use avoid_final_parameters
     prefer_final_parameters: false
 
+    # Conflicts with `omit_local_variable_types`
+    specify_nonobvious_local_variable_types: false
+
     # Incompatible with `prefer_final_locals`
     # Having immutable local variables makes larger functions more predictable
     # so we will use `prefer_final_locals` instead.


### PR DESCRIPTION
## 🙌 What's Done
<!-- What has been done in this Pull Request? -->
- Disable `specify_nonobvious_local_variable_types` to avoid conflicts

After upgrading to Flutter 3.27.0, warnings for `specify_nonobvious_local_variable_types`—enabled since version 3.6—started appearing.  
As noted [here](https://zenn.dev/altiveinc/articles/update-dart-lint-rules-2024-11#specify_nonobvious_local_variable_types), since we are using `omit_local_variable_types`, we cannot adopt `specify_nonobvious_local_variable_types`.  
Therefore, we disabled it.

## ✍️ What's Not Done
<!-- What is not done in this Pull Request? If none, write "None". -->
- None

## 🖼️ Image Differences
<!-- Attach Before and After capture images or videos if there are UI changes. -->

| Before    | After     |
| --------- | --------- |
| __image__ | __image__ |

## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [ ] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

## Pre-launch Checklist
- [x] I have reviewed my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I updated/added relevant documentation (doc comments with ///).