### PR TITLE
fix: disable unnecessary_async lint rule to resolve conflicts with other lint patterns

### DIFF
--- a/packages/altive_lints/lib/altive_lints.yaml
+++ b/packages/altive_lints/lib/altive_lints.yaml
@@ -59,6 +59,13 @@ linter:
     # Conflicts with `omit_local_variable_types`
     specify_nonobvious_local_variable_types: false
 
+    # Conflicts with `discarded_futures` and `unnecessary_await_in_return` with arrow syntax.
+    # Lint patterns:
+    # - onTap: () => someFuture(arg: someValue), // LINT: discarded_futures
+    # - onTap: () async => await someFuture(arg: someValue), // LINT: unnecessary_await_in_return
+    # - onTap: () async => someFuture(arg: someValue), // LINT: unnecessary_async
+    unnecessary_async: false
+
     # Incompatible with `prefer_final_locals`
     # Having immutable local variables makes larger functions more predictable
     # so we will use `prefer_final_locals` instead.


### PR DESCRIPTION
## 🙌 What's Done
<!-- What has been done in this Pull Request? -->
- discarded_futures, unnecessary_async, unnecessary_await_in_return All enabled, you won't be able to write asynchronous functions in arrow notation.

## ✍️ What's Not Done
<!-- What is not done in this Pull Request? If none, write "None". -->
- 

## 🖼️ Image Differences
<!-- Attach Before and After capture images or videos if there are UI changes. -->

![image](https://github.com/user-attachments/assets/00ef10b6-f69f-4356-9833-a3a7b151f407)

| Before    | After     |
| --------- | --------- |
| __image__ | __image__ |

## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [ ] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

## Pre-launch Checklist
- [x] I have reviewed my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I updated/added relevant documentation (doc comments with ///).