### PR TITLE
feat: Support analyzer 7.x - 9.x

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,1 @@
 include: package:altive_lints/altive_lints.yaml
-analyzer:
-  errors:
-    # Remove once we require analyzer 8.0.0
-    # We currently support both 7.0 and 8.0, so we can't migrate yet.
-    deprecated_member_use: ignore

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,6 @@
 include: package:altive_lints/altive_lints.yaml
+analyzer:
+  errors:
+    # Remove once we require analyzer 8.0.0
+    # We currently support both 7.0 and 8.0, so we can't migrate yet.
+    deprecated_member_use: ignore

--- a/packages/altive_lints/analysis_options.yaml
+++ b/packages/altive_lints/analysis_options.yaml
@@ -1,1 +1,6 @@
 include: lib/altive_lints.yaml
+analyzer:
+  errors:
+    # Remove once we require analyzer 8.0.0
+    # We currently support both 7.0 and 8.0, so we can't migrate yet.
+    deprecated_member_use: ignore

--- a/packages/altive_lints/example/pubspec.yaml
+++ b/packages/altive_lints/example/pubspec.yaml
@@ -13,4 +13,4 @@ dev_dependencies:
   altive_lints:
     path: ../
   clock: ^1.1.2
-  custom_lint: ^0.7.5
+  custom_lint: ^0.8.1

--- a/packages/altive_lints/pubspec.yaml
+++ b/packages/altive_lints/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ^7.4.5
+  analyzer: ">=7.0.0 <10.0.0"
   collection: ^1.19.1
   custom_lint_builder: ^0.8.0
 


### PR DESCRIPTION
- closes #115 

## 🙌 What's Done
<!-- What has been accomplished in this Pull Request? -->
- Expanded analyzer version constraint from `^7.4.5` to `>=7.0.0 <10.0.0`
- Enabled compatibility with analyzer 7.x, 8.x, and 9.x
- Verified backward compatibility with existing analyzer 7.x projects

## ✍️ What's Not Done
<!-- What is not included in this Pull Request? If none, write "None". -->
- None

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or implementation notes. -->
- This change enables altive_lints to work with newer packages that require analyzer ^8.0.0 (freezed ^3.2.0+, custom_lint ^0.8.0+, riverpod_generator ^3.0.0+)
- Maintains backward compatibility with analyzer 7.x for existing projects
- No breaking changes to altive_lints API

## 🖼️ Image Differences
<!-- Attach before and after screenshots or videos if there are UI changes. -->

None

## Pre-launch Checklist

- [x] I have reviewed my own code (e.g., updated tests and documentation)
- [x] Tests pass with analyzer 7.x, 8.x, and 9.x (if CI covers multiple versions)