### PR TITLE
fix: Change the plugin version specification method

### DIFF
--- a/packages/altive_lints/CHANGELOG.md
+++ b/packages/altive_lints/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!-- cSpell:words masa -->
+## 2.0.0-dev.3
+
+ - **DOCS**: Fix the notation for enabling the plugin in README.md.
+ - **FIX**: Change plugin specification in altive_lints from path to version.
+
 ## 2.0.0-dev.2
 
  - **FIX**: Changed the AnalysisRule that had been registered as a Warning rule to be registered as a Lint rule.

--- a/packages/altive_lints/README.md
+++ b/packages/altive_lints/README.md
@@ -35,16 +35,19 @@ Provides `all_lint_rules.yaml` that activates all lint rules and `altive_lints.y
 ### altive_lints
 
 1. Add altive_lints to your `pubspec.yaml`:
-  ```yaml
-  dev_dependencies:
-    altive_lints:
-  ```
+```yaml
+dev_dependencies:
+  altive_lints:
+```
 2. Include altive_lints in analysis_options.yaml.<br/>
 If not, create a new one or copy [analysis_options.yaml](https://github.com/altive/altive_lints/blob/main/packages/altive_lints/example/analysis_options.yaml) and use it.
 
-  ```yaml
-  include: package:altive_lints/altive_lints.yaml
-  ```
+```yaml
+include: package:altive_lints/altive_lints.yaml
+plugins:
+  altive_lints:
+    version: ^2.0.0-dev.3
+```
 
 ### Disabling lint rules/analysis rules
 
@@ -60,6 +63,7 @@ linter:
 
 plugins:
   altive_lints:
+    version: ^2.0.0-dev.3
     diagnostics:
       # Explicitly disable one analysis rule.
       avoid_consecutive_sliver_to_box_adapter: false

--- a/packages/altive_lints/lib/altive_lints.yaml
+++ b/packages/altive_lints/lib/altive_lints.yaml
@@ -16,7 +16,7 @@ formatter:
 
 plugins:
   altive_lints:
-    path: ../../altive_lints
+    version: ^2.0.0-dev.3
     diagnostics:
       avoid_consecutive_sliver_to_box_adapter: true
       avoid_hardcoded_color: true

--- a/packages/altive_lints/lib/main.dart
+++ b/packages/altive_lints/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:analysis_server_plugin/plugin.dart';
 import 'package:analysis_server_plugin/registry.dart';
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
 
 import 'src/assists/add_macro_document_comments.dart';
 import 'src/assists/add_macro_template_document_comment.dart';
@@ -25,19 +26,21 @@ class _Plugin extends Plugin {
 
   @override
   Future<void> register(PluginRegistry registry) async {
+    <AnalysisRule>[
+      AvoidConsecutiveSliverToBoxAdapter(),
+      AvoidHardcodedColor(),
+      AvoidHardcodedJapanese(),
+      AvoidShrinkWrapInListView(),
+      AvoidSingleChild(),
+      PreferClockNow(),
+      PreferDedicatedMediaQueryMethods(),
+      PreferSpaceBetweenElements(),
+      PreferToIncludeSliverInName(),
+    ].forEach(registry.registerLintRule);
+
     registry
-      ..registerLintRule(AvoidConsecutiveSliverToBoxAdapter())
-      ..registerLintRule(AvoidHardcodedColor())
-      ..registerLintRule(AvoidHardcodedJapanese())
-      ..registerLintRule(AvoidShrinkWrapInListView())
-      ..registerLintRule(AvoidSingleChild())
-      ..registerLintRule(PreferClockNow())
-      ..registerLintRule(PreferDedicatedMediaQueryMethods())
-      ..registerLintRule(PreferSpaceBetweenElements())
-      ..registerLintRule(PreferToIncludeSliverInName())
       ..registerAssist(AddMacroDocumentComment.new)
       ..registerAssist(AddMacroTemplateDocumentComment.new)
-      ..registerAssist(WrapWithMacroTemplateDocumentComment.new)
-    /* */;
+      ..registerAssist(WrapWithMacroTemplateDocumentComment.new);
   }
 }

--- a/packages/altive_lints/pubspec.yaml
+++ b/packages/altive_lints/pubspec.yaml
@@ -2,14 +2,17 @@ name: altive_lints
 description: >-
   Provides `all_lint_rules.yaml` that activates all rules and
   `altive_lints.yaml` with Altive recommended rule selection.
-version: 2.0.0-dev.2
+version: 2.0.0-dev.3
 homepage: https://altive.dev
 repository: https://github.com/altive/altive_lints
 issue_tracker: https://github.com/altive/altive_lints/issues
 topics:
+  - lint
+  - lints
+  - linter
+  - code-style
   - analysis
   - analyzer
-  - lints
 
 resolution: workspace
 


### PR DESCRIPTION
## 🙌 What's Done
<!-- What has been accomplished in this Pull Request? -->
- Change the plugin version specification method
- bump to altive_lints: 2.0.0-dev.3

## ✍️ What's Not Done
## Pre-launch Checklist

- [x] I have reviewed my own code (e.g., updated tests and documentation)
