### PR TITLE
build: update altive_lints to 2.0.0 stable

### DIFF
--- a/packages/altive_lints/CHANGELOG.md
+++ b/packages/altive_lints/CHANGELOG.md
@@ -1,4 +1,14 @@
-<!-- cSpell:words masa -->
+<!-- cSpell:ignore masa -->
+## 2.0.0
+
+ A stable release for altive_lints 2.0.
+
+ - Upgrade minimum required Dart SDK version to 3.10.0.
+ - Upgrade minimum required analyzer version to 9.0.0.
+ - **FEAT**: Migrate to Analyzer Plugin (analysis_server_plugin) from custom_lint.
+ - **FEAT**: prefer_dedicated_media_query_methods warns against using MediaQuery.sizeOf(context).width/height.
+ use MediaQuery.widthOf(context) and MediaQuery.heightOf(context) instead.
+ 
 ## 2.0.0-dev.3
 
  - **DOCS**: Fix the notation for enabling the plugin in README.md.
@@ -15,7 +25,6 @@
  - **FEAT**: Migrate to analysis_server_plugin from custom_lint.
  - **FEAT**: prefer_dedicated_media_query_methods warns against using MediaQuery.sizeOf(context).width/height.
  use MediaQuery.widthOf(context) and MediaQuery.heightOf(context) instead.
-
 
 ## 1.25.0
 

--- a/packages/altive_lints/README.md
+++ b/packages/altive_lints/README.md
@@ -44,9 +44,6 @@ If not, create a new one or copy [analysis_options.yaml](https://github.com/alti
 
 ```yaml
 include: package:altive_lints/altive_lints.yaml
-plugins:
-  altive_lints:
-    version: ^2.0.0-dev.3
 ```
 
 ### Disabling lint rules/analysis rules
@@ -63,7 +60,7 @@ linter:
 
 plugins:
   altive_lints:
-    version: ^2.0.0-dev.3
+    version: ^2.0.0
     diagnostics:
       # Explicitly disable one analysis rule.
       avoid_consecutive_sliver_to_box_adapter: false

--- a/packages/altive_lints/lib/altive_lints.yaml
+++ b/packages/altive_lints/lib/altive_lints.yaml
@@ -16,7 +16,7 @@ formatter:
 
 plugins:
   altive_lints:
-    version: ^2.0.0-dev.3
+    version: ^2.0.0
     diagnostics:
       avoid_consecutive_sliver_to_box_adapter: true
       avoid_hardcoded_color: true

--- a/packages/altive_lints/pubspec.yaml
+++ b/packages/altive_lints/pubspec.yaml
@@ -2,16 +2,15 @@ name: altive_lints
 description: >-
   Provides `all_lint_rules.yaml` that activates all rules and
   `altive_lints.yaml` with Altive recommended rule selection.
-version: 2.0.0-dev.3
+version: 2.0.0
 homepage: https://altive.dev
 repository: https://github.com/altive/altive_lints
 issue_tracker: https://github.com/altive/altive_lints/issues
-topics:
+topics: # up to 5 topics are allowed
   - lint
   - lints
   - linter
   - code-style
-  - analysis
   - analyzer
 
 resolution: workspace
@@ -20,12 +19,12 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  analysis_server_plugin: ^0.3.0
-  analyzer: ">=8.0.0 <10.0.0"
+  analysis_server_plugin: ^0.3.4
+  analyzer: ^9.0.0
   analyzer_plugin: ^0.13.11
   collection: ^1.19.1
 
 dev_dependencies:
   analyzer_testing: ^0.1.7
-  test: ^1.26.2
+  test: ^1.28.0
   test_reflective_loader: ^0.4.0


### PR DESCRIPTION
I've confirmed that it works correctly with newly created Flutter projects (flutter create) and the flutter_app_template,
 so I plan to release it as a stable version.

## 🙌 What's Done
<!-- What has been accomplished in this Pull Request? -->
- Upgrade minimum required `analyzer` version to 9.0.0.
  - Because the `analysis_server_plugin` and `analyzer_plugin` packages depend on analyzer v9.

## Pre-launch Checklist

- [x] I have reviewed my own code (e.g., updated tests and documentation)
